### PR TITLE
CI: Add repo trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
   docs-build:
     name: Build docs
     runs-on: ubuntu-latest
+    if: (github.repository == 'astropy/repo_stats')
 
     steps:
       - name: Check out repo
@@ -55,8 +56,9 @@ jobs:
   docs-deploy:
     name: Deploy docs
     needs: docs-build
-    # if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    if: (github.repository == 'astropy/repo_stats')
+    # if: github.event.pull_request.merged == true
     permissions: 
       contents: write
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-20.04
+    if: (github.repository == 'astropy/repo_stats')
 
     steps:
       - name: Check out repo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    if: (github.repository == 'astropy/repo_stats')
     
     strategy:
       matrix:

--- a/.github/workflows/update_stats.yml
+++ b/.github/workflows/update_stats.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: (github.repository == 'astropy/repo_stats')
     permissions: 
       contents: write    
 


### PR DESCRIPTION
Ensures CI (github actions workflows) are only triggered by `astropy/repo_stats`, not a fork.

closes #3 