### PR TITLE
Remove hardcode of runner ubuntu version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: (github.repository == 'astropy/repo_stats')
 
     steps:


### PR DESCRIPTION
The actions workflow `package.yml` runs on a hardcoded version of ubuntu, which will be deprecated soon. This PR changes to `ubuntu-latest` (like the other workflows).